### PR TITLE
how about using absolute path in README.md?

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,20 @@ You might be interested in the [Tech Interview Handbook](https://github.com/yang
 
 ## Table of Contents
 
-1. [HTML Questions](questions/html-questions.md)
-1. [CSS Questions](questions/css-questions.md)
-1. [JavaScript Questions](questions/javascript-questions.md)
+1. [HTML Questions](/questions/html-questions.md)
+1. [CSS Questions](/questions/css-questions.md)
+1. [JavaScript Questions](/questions/javascript-questions.md)
 
 ## Translations
 
-* [Simplified Chinese (简体中文)](Translations/Chinese/README.md)
-* [Tagalog](Translations/Tagalog/README.md)
+* [English](/README.md)
+* [Simplified Chinese (简体中文)](/Translations/Chinese/README.md)
+* [Tagalog](/Translations/Tagalog/README.md)
 
 **In Progress**
 
-* [Korean](Translations/Korean/README.md)
-* [Japanese (日本語)](Translations/Japanese/README.md)
+* [Korean](/Translations/Korean/README.md)
+* [Japanese (日本語)](/Translations/Japanese/README.md)
 
 ## Related
 
@@ -49,8 +50,8 @@ We have adopted the same Code of Conduct as Facebook that we expect project part
 
 ### Contributing Guide
 
-Read our [contributing guide](CONTRIBUTING.md) to learn about how you can contribute, how to propose improvements or if you are interested in translating the content.
+Read our [contributing guide](/CONTRIBUTING.md) to learn about how you can contribute, how to propose improvements or if you are interested in translating the content.
 
 ## License
 
-All projects and packages in this repository are [MIT licensed](LICENSE).
+All projects and packages in this repository are [MIT licensed](/LICENSE).


### PR DESCRIPTION
When we translate and put them in /Translations, relative paths do not work well.
So, how about to use absolute ones even in original README.md?
And I added links to original(English) link mainly the purpose from translations.
