### PR TITLE
Adds typeof example for null values

### DIFF
--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -171,13 +171,13 @@ A variable that is `null` will have been explicitly assigned to the `null` value
 
 ```js
 var foo = null;
-console.log(typeof foo); //object
 console.log(foo === null); // true
+console.log(typeof foo === 'object'); // true
 
 console.log(foo == undefined); // true. Wrong, don't use this to check!
 ```
 
-As a personal habit, I never leave my variables undeclared or unassigned. I will explicitly assign `null` to them after declaring if I don't intend to use it yet.
+As a personal habit, I never leave my variables undeclared or unassigned. I will explicitly assign `null` to them after declaring if I don't intend to use it yet. If you use a linter in your workflow, it will usually also be able to check that you are not referencing undeclared variables.
 
 ###### References
 

--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -171,6 +171,7 @@ A variable that is `null` will have been explicitly assigned to the `null` value
 
 ```js
 var foo = null;
+console.log(typeof foo); //object
 console.log(foo === null); // true
 
 console.log(foo == undefined); // true. Wrong, don't use this to check!


### PR DESCRIPTION
I believe it is a key characteristic between undefined variables and null variables, that being that typeof null evaluates to `object` while this same isn't true for undefined variables.

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
