### PR TITLE
Fixed a typo in HTML questions. Fixes issue #150

### DIFF
--- a/questions/html-questions.md
+++ b/questions/html-questions.md
@@ -21,7 +21,7 @@ A DOCTYPE is always associated to a **DTD** - for **Document Type Definition**.
 
 A DTD defines how documents of a certain type should be structured (i.e. a `button` can contain a `span` but not a `div`), whereas a DOCTYPE declares what DTD a document *supposedly* respects (i.e. this document respects the HTML DTD).  
 
-For webpages, the DOCTYPE declation is required. It is used to tell user agents what version of the HTML specifications your document respects.  
+For webpages, the DOCTYPE declaration is required. It is used to tell user agents what version of the HTML specifications your document respects.  
 Once a user agent has recognized a correct DOCTYPE, it will trigger the **no-quirks mode** matching this DOCTYPE for reading the document.  
 If a user agent doesn't recognize a correct DOCTYPE, it will trigger the **quirks mode**.
 


### PR DESCRIPTION
Found and fixed a typo in front-end-interview-handbook/questions/html-questions.md on line 24.
Original word - declation.
Changed to - declaration.