### PR TITLE
[CSS] Mention presentational attribute specificity vs. CSS in SVG question

### DIFF
--- a/questions/css-questions.md
+++ b/questions/css-questions.md
@@ -230,6 +230,8 @@ Basic coloring can be done by setting two attributes on the node: `fill` and `st
   fill="purple" fill-opacity="0.5" stroke-opacity="0.8"/>
 ```
 
+The above `fill="purple"` is an example of a _presentational attribute_. Interestingly, and unlike inline styles like `style="fill: purple"` which also happens to be an attribute, presentational attributes can be [overriden by CSS](https://css-tricks.com/presentation-attributes-vs-inline-styles/) styles defined in a stylesheet. So, if you did something like `svg { fill: blue; }` it would override the purple fill we've defined.
+
 ###### References
 
 * https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Fills_and_Strokes


### PR DESCRIPTION

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
Discuss presentational attributes being overridable by externally defined CSS. This is an important concept to understand for SVG specifically, since it's counterintuitive that something defined in an attribute has less specificity then outside CSS.