### PR TITLE
Fixes Object.create(Person.prototype) example

### DIFF
--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -308,9 +308,16 @@ Host objects are provided by the runtime environment (browser or Node), such as 
 
 This question is pretty vague. My best guess at its intention is that it is asking about constructors in JavaScript. Technically speaking, `function Person(){}` is just a normal function declaration. The convention is to use PascalCase for functions that are intended to be used as constructors.
 
+According to the [MDN docs], `new` keyword will do the following:
+
+> 1. Creates a blank, plain JavaScript object;
+> 2. Links (sets the constructor of) this object to another object;
+> 3. Passes the newly created object from Step 1 as the this context;
+> 4. Returns this if the function doesn't return its own object.
+
 `var person = Person()` invokes the `Person` as a function, and not as a constructor. Invoking as such is a common mistake if the function is intended to be used as a constructor. Typically, the constructor does not return anything, hence invoking the constructor like a normal function will return `undefined` and that gets assigned to the variable intended as the instance.
 
-`var person = new Person()` creates an instance of the `Person` object using the `new` operator, which inherits from `Person.prototype`. An alternative would be to use `Object.create`, such as: `Object.create(Person.prototype)`.
+`var person = new Person()` creates an instance of the `Person` object using the `new` operator, which inherits from `Person.prototype`. An alternative would be to use `Object.create`, such as: `Object.create(new Person('Larry'))`.
 
 ```js
 function Person(name) {
@@ -324,6 +331,17 @@ console.log(person.name); // Uncaught TypeError: Cannot read property 'name' of 
 var person = new Person('John');
 console.log(person); // Person { name: "John" }
 console.log(person.name); // "john"
+```
+
+#### Extra Credit—`Object.create`:
+
+And here's how you'd achieve the same as above, but with `Object.create`:
+
+```js
+var joe = Object.create(Person.prototype); // Won't work doesn't set "own property" name
+joe.name; // Outputs: undefined
+var larry = Object.create(new Person('Larry'))
+larry.name; // Outputs: Larry
 ```
 
 ###### References


### PR DESCRIPTION
<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->

`Object.create(Person.prototype)` actually won't quite work the same as it won't properly set up the `this.name`. I think this is pretty subtle but worth showing an explicit example.

Alternatively, we could just remove the reference to using `Object.create` at all since it's not really part of the original question. However, I liked the fact that you mentioned it as a sort of extra credit thing :) 

Also, I elected to block quote the MDN docs on exactly what happens when you use `new F`.

Also, you probably meant if we used it like:

```js
var joe = Object.create(Person.prototype);
joe.name = 'Joe';
console.log(joe.name);
```

which would work haha...so I dunno lol. That said, it's a bit different since you're setting the owned property after the creation step.