### PR TITLE
amend rule #3 on "explain how 'this' works" js question

### DIFF
--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -77,7 +77,7 @@ There's no simple explanation for `this`; it is one of the most confusing concep
 
 1. If the `new` keyword is used when calling the function, `this` inside the function is a brand new object.
 2. If `apply`, `call`, or `bind` are used to call/create a function, `this` inside the function is the object that is passed in as the argument.
-3. If a function is called as a method, such as `obj.method()` — `this` is the object that the function is a property of.
+3. If a function is called as a method, such as `obj.method()` — `this` is the object to the left of the dot when the function is called.
 4. If a function is invoked as a free function invocation, meaning it was invoked without any of the conditions present above, `this` is the global object. In a browser, it is the `window` object. If in strict mode (`'use strict'`), `this` will be `undefined` instead of the global object.
 5. If multiple of the above rules apply, the rule that is higher wins and will set the `this` value.
 6. If the function is an ES2015 arrow function, it ignores all the rules above and receives the `this` value of its surrounding scope at the time it is created.


### PR DESCRIPTION
This change provides a more precise and correct explanation for the behavior of the keyword `this` as described in rule 3. Attention is given to cases where the method being called is actually inherited from a prototype object--in which case 'this' would reference the object left of the dot, not the object of which the function is a property. (see explanation below)


>3. If a function is called as a method, such as `obj.method()` — `this` is the object that the function is a property of.

This is often the case, but not always. Observe the code below:

```
const Animal = {
  catchPhrase: "I'm on the Animal object!",
  testMethod: function() {
    console.log(this.catchPhrase);
  }
}; // set up a basic Animal object with a catchPhrase property and a testMethod method referencing the keyword 'this'.

const Kitty = Object.create(Animal); // create an empty object which is a subclass of Animal--i.e., Animal is Kitty's prototype.

Kitty.catchPhrase = "I'm on the Kitty object!"; // give Kitty its own catchPhrase property to differentiate it from Animal. catchPhrase is now the sole property on the Kitty object.

Kitty.testMethod(); // "I'm on the Kitty object!"
// testMethod is not found on Kitty, so the lookup falls back to the prototype, Animal. According to the existing explanation, when testMethod() references 'this', Animal should be the object referenced, as Animal is the object that testMethod is found on. However, that's not the case. 'this' refers instead to Kitty, the object left of the dot when the function is called--even though the function doesn't even exist on that object.
```
