### PR TITLE
[css] delete misleading statement in pseudo-elements question

### DIFF
--- a/questions/css-questions.md
+++ b/questions/css-questions.md
@@ -349,7 +349,7 @@ A CSS pseudo-element is a keyword added to a selector that lets you style a spec
 
 - `:first-line` and `:first-letter` can be used to decorate text.
 - Used in the `.clearfix` hack as shown above to add a zero-space element with `clear: both`.
-- Triangular arrows in tooltips use `:before` and `:after`. Encourages separation of concerns because the triangle is considered part of styling and not really the DOM. It's not really possible to draw a triangle with just CSS styles without using an additional HTML element.
+- Triangular arrows in tooltips use `:before` and `:after`. Encourages separation of concerns because the triangle is considered part of styling and not really the DOM.
 
 ###### References
 


### PR DESCRIPTION
This is a proposal for removing the last phrase of the question "Describe pseudo-elements and discuss what they are used for."

The aforementioned phrase is "It's not really possible to draw a triangle with just CSS styles without using an additional HTML element.". It is easy and totally fine to "draw" any shape by using the CSS "content" property of the before/after pseudo elements. This is why I believe that it is a little bit "misleading".

This technique serves what is mentioned in the answer "Encourages separation of concerns because the triangle is considered part of styling and not really the DOM".

A reference with a list of shapes can be found here: https://css-tricks.com/the-shapes-of-css/

Note: you do not have to add an empty html element and style it to draw a shape. You can just do that by using the pseudo elements.

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
