### PR TITLE
[js] fix prototypal inheritance question from "prototype" to "__proto__"

### DIFF
--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -97,7 +97,7 @@ ES6 allows you to use [arrow functions](http://2ality.com/2017/12/alternate-this
 
 ### Explain how prototypal inheritance works
 
-This is an extremely common JavaScript interview question. All JavaScript objects have a `prototype` property, that is a reference to another object. When a property is accessed on an object and if the property is not found on that object, the JavaScript engine looks at the object's `prototype`, and the `prototype`'s `prototype` and so on, until it finds the property defined on one of the `prototype`s or until it reaches the end of the prototype chain. This behavior simulates classical inheritance, but it is really more of [delegation than inheritance](https://davidwalsh.name/javascript-objects).
+This is an extremely common JavaScript interview question. All JavaScript objects have a `__proto__` property, that is a reference to another object, which called object's "prototype". When a property is accessed on an object and if the property is not found on that object, the JavaScript engine looks at the object's `__proto__`, and the `__proto__`'s `__proto__` and so on, until it finds the property defined on one of the `__proto__`s or until it reaches the end of the prototype chain. This behavior simulates classical inheritance, but it is really more of [delegation than inheritance](https://davidwalsh.name/javascript-objects).
 
 #### Example of Prototypal Inheritance
 

--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -97,7 +97,7 @@ ES6 allows you to use [arrow functions](http://2ality.com/2017/12/alternate-this
 
 ### Explain how prototypal inheritance works
 
-This is an extremely common JavaScript interview question. All JavaScript objects have a `__proto__` property, that is a reference to another object, which called object's "prototype". When a property is accessed on an object and if the property is not found on that object, the JavaScript engine looks at the object's `__proto__`, and the `__proto__`'s `__proto__` and so on, until it finds the property defined on one of the `__proto__`s or until it reaches the end of the prototype chain. This behavior simulates classical inheritance, but it is really more of [delegation than inheritance](https://davidwalsh.name/javascript-objects).
+This is an extremely common JavaScript interview question. All JavaScript objects have a `__proto__` property, that is a reference to another object, which is called the object's "prototype". When a property is accessed on an object and if the property is not found on that object, the JavaScript engine looks at the object's `__proto__`, and the `__proto__`'s `__proto__` and so on, until it finds the property defined on one of the `__proto__`s or until it reaches the end of the prototype chain. This behavior simulates classical inheritance, but it is really more of [delegation than inheritance](https://davidwalsh.name/javascript-objects).
 
 #### Example of Prototypal Inheritance
 
@@ -176,6 +176,7 @@ c.constructor.name;
 
 ###### References
 
+- http://dmitrysoshnikov.com/ecmascript/javascript-the-core/
 - https://www.quora.com/What-is-prototypal-inheritance/answer/Kyle-Simpson
 - https://davidwalsh.name/javascript-objects
 - https://crockford.com/javascript/prototypal.html


### PR DESCRIPTION
Fixed issue found in [Explain how prototypal inheritance works](https://github.com/yangshun/front-end-interview-handbook/blob/master/questions/javascript-questions.md#explain-how-prototypal-inheritance-works) answer.

Actually, answer describes how the `__proto__` works. Unlike `__proto__`, `prototype` is a constructor function's property, which determines the inheritance chain.

[stackoverflow](https://stackoverflow.com/a/9959753)
[w3c](https://www.w3schools.com/js/js_object_prototypes.asp)
