### PR TITLE
[css] remove incorrect "visibility: hidden" answer from visually hide content question

### DIFF
--- a/questions/css-questions.md
+++ b/questions/css-questions.md
@@ -195,7 +195,6 @@ CSS sprites combine multiple images into one single larger image. It is a common
 
 These techniques are related to accessibility (a11y).
 
-- `visibility: hidden`. However, the element is still in the flow of the page, and still takes up space.
 - `width: 0; height: 0`. Make the element not take up any space on the screen at all, resulting in not showing it.
 - `position: absolute; left: -99999px`. Position it outside of the screen.
 - `text-indent: -9999px`. This only works on text within the `block` elements.


### PR DESCRIPTION
The answer to this question lists visibility: hidden. visibility: hidden; hides content from screen readers, so it should be excluded from the list.

https://github.com/yangshun/front-end-interview-handbook/issues/241