### PR TITLE
Remove redundant url link

### DIFF
--- a/contents/en/javascript-questions.md
+++ b/contents/en/javascript-questions.md
@@ -1094,7 +1094,6 @@ If you haven't already checked out Philip Robert's [talk on the Event Loop](http
 ###### References
 
 - https://2014.jsconf.eu/speakers/philip-roberts-what-the-heck-is-the-event-loop-anyway.html
-- http://theproactiveprogrammer.com/javascript/the-javascript-event-loop-a-stack-and-a-queue/
 
 [[↑] Back to top](#table-of-contents)
 


### PR DESCRIPTION
Removed redundant [url link](http://theproactiveprogrammer.com/javascript/the-javascript-event-loop-a-stack-and-a-queue/) for this [question](https://yangshun.github.io/front-end-interview-handbook/en/javascript-questions/#what-is-event-loop-what-is-the-difference-between-call-stack-and-task-queue). It's no longer available in the web.
