### PR TITLE
website: fix style in GitHub stars in home page

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -36,7 +36,7 @@ function Home() {
               src="https://ghbtns.com/github-btn.html?user=yangshun&amp;repo=front-end-interview-handbook&amp;type=star&amp;count=true&amp;size=large"
               frameBorder={0}
               scrolling={0}
-              width={160}
+              width={165}
               height={30}
               title="GitHub Stars"
             />


### PR DESCRIPTION
this little PR fix style in Github starts logo.

Before:
![image](https://user-images.githubusercontent.com/36824170/117047329-5e00f800-acd7-11eb-8ac0-4270956a9ae1.png)


After:
![image](https://user-images.githubusercontent.com/36824170/117047401-7244f500-acd7-11eb-85a6-ea6ca65703b0.png)
