### PR TITLE
website: fix title header size in responsive mobile

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -12,7 +12,7 @@ function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
   return (
-    <Layout title={siteConfig.title} description={siteConfig.tagline}>
+    <Layout title={siteConfig.title} class="title__header" description={siteConfig.tagline}>
       <header className={classnames('hero', styles.heroBanner)}>
         <div className="container">
           <img

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -5,6 +5,11 @@
   overflow: hidden;
 }
 
+.title__header {
+  font-size: 17px;
+}
+
+
 .heroBannerLogo {
   max-width: 300px;
 }
@@ -44,3 +49,4 @@
 .quote {
   font-size: 1.1rem;
 }
+


### PR DESCRIPTION
this PR fix style size in mobile responsive and inside hamburger menu, especially in iphone screen sizes looks bad 

before:
![Screen Shot 2021-05-05 at 10 35 31](https://user-images.githubusercontent.com/36824170/117168904-328d1480-ad8e-11eb-98b8-a14de9fa7336.png)


after:
![Screen Shot 2021-05-05 at 10 35 53](https://user-images.githubusercontent.com/36824170/117168947-40429a00-ad8e-11eb-8943-7ea46161d037.png)
