### PR TITLE
Fix prototypal inheritance code

### DIFF
--- a/contents/en/javascript-questions.md
+++ b/contents/en/javascript-questions.md
@@ -163,7 +163,7 @@ function Child() {
   this.name = 'child';
 }
 
-Child.prototype = Parent.prototype;
+Child.prototype = Object.create(Parent.prototype);
 Child.prototype.constructor = Child;
 
 const c = new Child();


### PR DESCRIPTION
In JavaScript questions, under 
"Explain how prototypal inheritance works"
The following code looks incorrect.
```
Child.prototype = Parent.prototype;
Child.prototype.constructor = Child;
```
Parent.prototype.constructor is being overwritten into Child.
<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
