### PR TITLE
fix: broken utility function link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You might be interested in the [Tech Interview Handbook](https://techinterviewha
 ## Table of Contents
 
 1. [Pop Quiz Questions](https://frontendinterviewhandbook.com/pop-quiz/)
-1. [JavaScript Utility Function Questions](https://frontendinterviewhandbook.com/utility-functions/)
+1. [JavaScript Utility Function Questions](https://frontendinterviewhandbook.com/utility-function/)
 1. [Front End Coding Questions](https://frontendinterviewhandbook.com/build-user-interfaces/)
 1. [JavaScript Algorithm Questions](https://frontendinterviewhandbook.com/algorithms/)
 1. [Front End System Design Questions](https://frontendinterviewhandbook.com/front-end-system-design/)


### PR DESCRIPTION
<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->

The hyperlink to JavaScript Utility Function Questions in the README has an extra character.