### PR TITLE
optimised #314

### DIFF
--- a/contents/css-questions.md
+++ b/contents/css-questions.md
@@ -201,7 +201,7 @@ These techniques are related to accessibility (a11y).
 
 - `width: 0; height: 0`. Make the element not take up any space on the screen at all, resulting in not showing it.
 - `position: absolute; left: -99999px`. Position it outside of the screen.
-- `text-indent: -9999px`. This only works on text within the `block` elements.
+- `text-indent: 100%; white-space: nowrap; overflow: hidden;`. This only works on text within the `block` elements.
 - Meta tags. For example by using Schema.org, RDF, and JSON-LD.
 - WAI-ARIA. A W3C technical specification that specifies how to increase the accessibility of web pages.
 

--- a/website/i18n/jp/docusaurus-plugin-content-docs/current/css-questions.md
+++ b/website/i18n/jp/docusaurus-plugin-content-docs/current/css-questions.md
@@ -197,7 +197,7 @@ CSS スプライトは、複数のイメージを 1 つの大きなイメージ�
 
 - `width: 0; height: 0`： 要素が画面上のスペースを全く占めないようにして、それを表示しないようにします。
 - `position: absolute; left: -99999px`： 画面の外側に配置します。
-- `text-indent: -9999px`： これは `block` 要素内のテキストに対してのみ機能します。
+- `text-indent: 100%; white-space: nowrap; overflow: hidden;`： これは `block` 要素内のテキストに対してのみ機能します。
 - メタデータ： たとえば、Schema.org、RDF、JSON-LD を使用します。
 - WAI-ARIA： Web ページのアクセシビリティを向上させる方法を指定する W3C の技術仕様。
 

--- a/website/i18n/kr/docusaurus-plugin-content-docs/current/css-questions.md
+++ b/website/i18n/kr/docusaurus-plugin-content-docs/current/css-questions.md
@@ -197,7 +197,7 @@ CSS 스프라이트는 여러 이미지를 하나의 큰 이미지로 결합합�
 
 - `width: 0; height: 0`. 요소가 화면의 어떤 공간도 차지하지 않도록 합니다. 결과적으로 보이지 않게 됩니다.
 - `position: absolute; left: -99999px`. 화면 외부에 배치합니다.
-- `text-indent: -9999px`. 이것은 `block`인 요소 내의 텍스트에서만 작동합니다.
+- `text-indent: 100%; white-space: nowrap; overflow: hidden;`. 이것은 `block`인 요소 내의 텍스트에서만 작동합니다.
 - 메타데이터. 예를 들면, Schema.org, RDF, JSON-LD를 사용합니다.
 - WAI-ARIA. 웹 페이지의 Accessibility를 높이는 방법을 정의하는 W3C 기술 사양입니다.
 

--- a/website/i18n/pl/docusaurus-plugin-content-docs/current/css-questions.md
+++ b/website/i18n/pl/docusaurus-plugin-content-docs/current/css-questions.md
@@ -201,7 +201,7 @@ Te techniki są związane z dostępnością (a11y).
 
 - `width: 0; height: 0`. Spraw, aby element nie zajmował w ogóle miejsca na ekranie, co powoduje, że nie jest pokazywany.
 - `position: absolute; left: -99999px`. Ustaw go poza ekranem.
-- `text-indent: -9999px`. Działa to tylko w przypadku tekstu w elementach `block`.
+- `text-indent: 100%; white-space: nowrap; overflow: hidden;`. Działa to tylko w przypadku tekstu w elementach `block`.
 - Metadane. Na przykład za pomocą Schema.org, RDF i JSON-LD.
 - WAI-ARIA. Specyfikacja techniczna W3C określająca sposób zwiększenia dostępności stron internetowych.
 

--- a/website/i18n/tl/docusaurus-plugin-content-docs/current/css-questions.md
+++ b/website/i18n/tl/docusaurus-plugin-content-docs/current/css-questions.md
@@ -195,7 +195,7 @@ Ang mga pamamaraan na ito ay may kaugnayan sa pagkakarating (a11y).
 
 - `width: 0; height: 0`. Gawin ang elemento na hindi kukuha ng anumang espasyo sa iskrin ng lahat, na magreresulta sa hindi pagpapakita nito.
 - `position: absolute; left: -99999px`. Ilagay ito sa labas ng iskrin.
-- `text-indent: -9999px`. Ito ay gagana lamang sa mga teksto sa loob ng `block` na mga elemento.
+- `text-indent: 100%; white-space: nowrap; overflow: hidden;`. Ito ay gagana lamang sa mga teksto sa loob ng `block` na mga elemento.
 - Metadata. Halimbawa ay sa paggamit ng Schema.org, RDF at JSON-LD.
 - WAI-ARIA. Isang W3C na teknikal na ispisipikasyon na tinutukoy kung paano madagdagan ang ang abilidad ng pag-akses ng mga pahina ng web.
 

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/css-questions.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/css-questions.md
@@ -195,7 +195,7 @@ CSS 中的`z-index`属性控制重叠元素的垂直叠加顺序。`z-index`只�
 
 - `width: 0; height: 0`：使元素不占用屏幕上的任何空间，导致不显示它。
 - `position: absolute; left: -99999px`： 将它置于屏幕之外。
-- `text-indent: -9999px`：这只适用于`block`元素中的文本。
+- `text-indent: 100%; white-space: nowrap; overflow: hidden;`：这只适用于`block`元素中的文本。
 - Metadata： 例如通过使用 Schema.org，RDF 和 JSON-LD。
 - WAI-ARIA：如何增加网页可访问性的 W3C 技术规范。
 


### PR DESCRIPTION
<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->

#314 

https://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/

As per the post above it is more efficient for the browser to use this method as opposed to the original styling of text-indent: -9999px as the old method can be taxing on older devices.
