### PR TITLE
Corrected typo in "Example of Prototypal Inheritance"

### DIFF
--- a/contents/javascript-questions.md
+++ b/contents/javascript-questions.md
@@ -86,9 +86,8 @@ Things to note are:
   - Object.create(Parent.prototype);
   - Object.create(new Parent(null));
   - Object.create(objLiteral);
-  - Currently, `child.constructor` is pointing to the `Parent`:
 
-If we'd like to correct this, one option would be to do:
+- Currently, `child.constructor` is pointing to the `Parent`. If we'd like to correct this, one option would be to do:
 
 ```js
 function Parent() {


### PR DESCRIPTION
In "Example of Prototypal Inheritance" section, there was an tab/spaces before '-' that caused "Currently, `child.constructor` is pointing to the `Parent`" to move to the list of ways to call Object.create().

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
