### PR TITLE
qns(quiz): describe how to prevent event bubbling

### DIFF
--- a/packages/quiz/questions/describe-event-bubbling/en-US.mdx
+++ b/packages/quiz/questions/describe-event-bubbling/en-US.mdx
@@ -2,4 +2,4 @@
 title: Describe event bubbling
 ---
 
-When an event triggers on a DOM element, it will attempt to handle the event if there is a listener attached, then the event is bubbled up to its parent and the same thing happens. This bubbling occurs up the element's ancestors all the way to the `document`. Event bubbling is the mechanism behind event delegation. To prevent event bubbling, you can use event.stopPropagation().
+When an event triggers on a DOM element, it will attempt to handle the event if there is a listener attached, then the event is bubbled up to its parent and the same thing happens. This bubbling occurs up the element's ancestors all the way to the `document`. Event bubbling is the mechanism behind event delegation. To prevent event bubbling, you can use `event.stopPropagation()`.

--- a/packages/quiz/questions/describe-event-bubbling/en-US.mdx
+++ b/packages/quiz/questions/describe-event-bubbling/en-US.mdx
@@ -2,4 +2,4 @@
 title: Describe event bubbling
 ---
 
-When an event triggers on a DOM element, it will attempt to handle the event if there is a listener attached, then the event is bubbled up to its parent and the same thing happens. This bubbling occurs up the element's ancestors all the way to the `document`. Event bubbling is the mechanism behind event delegation.
+When an event triggers on a DOM element, it will attempt to handle the event if there is a listener attached, then the event is bubbled up to its parent and the same thing happens. This bubbling occurs up the element's ancestors all the way to the `document`. Event bubbling is the mechanism behind event delegation. To prevent event bubbling, you can use event.stopPropagation().


### PR DESCRIPTION
Added information on how to prevent event bubbling to help with related follow up questions.

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
