### PR TITLE
fix(quiz): change to the correct way to inherit using prototype

### DIFF
--- a/packages/quiz/questions/explain-how-prototypal-inheritance-works/en-US.mdx
+++ b/packages/quiz/questions/explain-how-prototypal-inheritance-works/en-US.mdx
@@ -23,7 +23,7 @@ function Dog(name) {
 }
 
 // Set the child object's prototype to be a new instance of the parent object.
-Dog.prototype = Object.create(Animal.prototype);
+Object.setPrototypeOf(Dog.prototype, Animal.prototype)
 
 // Add a method to the child object's prototype.
 Dog.prototype.bark = function () {


### PR DESCRIPTION
Using Object.create to inherit prototype is a legacy method according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain 
Because it removes the dog constructor and the output will show `The Animal makes a sound` instead of `The Dog makes a sound`

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
