### PR TITLE
Fix Selector Traversal Explanation

### DIFF
--- a/packages/quiz/questions/explain-how-a-browser-determines-what-elements-match-a-css-selector/en-US.mdx
+++ b/packages/quiz/questions/explain-how-a-browser-determines-what-elements-match-a-css-selector/en-US.mdx
@@ -4,4 +4,4 @@ title: Explain how a browser determines what elements match a CSS selector.
 
 This question is related to the question about [writing efficient CSS](/questions/quiz/what-are-some-of-the-gotchas-for-writing-efficient-css). Browsers match selectors from rightmost (key selector) to the left. Browsers filter out elements in the DOM according to the key selector and traverse up its parent elements to determine matches. The shorter the length of the selector chain, the faster the browser can determine if that element matches the selector.
 
-For example, with a selector `p span`, browsers firstly find all the `<span>` elements and traverse up its parent all the way up to the root to find the `<p>` element. For a particular `<span>`, as soon as it finds a `<p>`, it knows that the `<span>` matches the selector, and can stop traversing its parents.
+For example, with a selector `p span`,  browsers find all the <span> elements and traverse up their parent chain, checking each ancestor element up to the root to find a <p> element. For each <span>, the browser continues traversing the DOM to find all matching <p> ancestors.

--- a/packages/quiz/questions/explain-how-a-browser-determines-what-elements-match-a-css-selector/en-US.mdx
+++ b/packages/quiz/questions/explain-how-a-browser-determines-what-elements-match-a-css-selector/en-US.mdx
@@ -4,4 +4,4 @@ title: Explain how a browser determines what elements match a CSS selector.
 
 This question is related to the question about [writing efficient CSS](/questions/quiz/what-are-some-of-the-gotchas-for-writing-efficient-css). Browsers match selectors from rightmost (key selector) to the left. Browsers filter out elements in the DOM according to the key selector and traverse up its parent elements to determine matches. The shorter the length of the selector chain, the faster the browser can determine if that element matches the selector.
 
-For example, with a selector `p span`,  browsers find all the <span> elements and traverse up their parent chain, checking each ancestor element up to the root to find a <p> element. For each <span>, the browser continues traversing the DOM to find all matching <p> ancestors.
+For example, with a selector `p span`,  browsers find all the `<span>` elements and traverse up their parent chain, checking each ancestor element up to the root to find a `<p>` element. For each `<span>`, the browser continues traversing the DOM to find all matching `<p>` ancestors.


### PR DESCRIPTION
Corrected the explanation regarding selector traversal in the browser. The previous statement inaccurately suggested that the browser stops traversing the DOM after finding the first matching parent element. In reality, it continues to traverse the DOM to identify all matching parent elements. The updated explanation provides a more accurate description of how browsers process selectors.

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
