### PR TITLE
quiz: add x-default suggestion to design or develop multilingual

### DIFF
--- a/packages/quiz/questions/designing-or-developing-for-multilingual-sites/en-US.mdx
+++ b/packages/quiz/questions/designing-or-developing-for-multilingual-sites/en-US.mdx
@@ -9,6 +9,7 @@ Designing and developing for multilingual sites is part of internationalization 
 - Use the `lang` attribute on the `<html>` tag.
 - Include the locale in the URL (e.g en_US, zh_CN, etc).
 - Webpages should use `<link rel="alternate" hreflang="other_locale" href="url_for_other_locale">` to tell search engines that there is another page at the specified `href` with the same content but for another language/locale.
+- Use a fallback page for unmatched languages. Use the "x-default" value: `<link rel="alternate" href="url_for_fallback" hreflang="x-default" />`.
 
 ## Understanding the difference between locale vs language
 


### PR DESCRIPTION
# Suggest using "x-default" as a fallback language

When developing a multilingual website, Google suggests adding an "x-default" link as an option when the user's browser default language is not supported by the website. [Reference here](https://developers.google.com/search/docs/specialty/international/localized-versions#all-method-guidelines).

## This PR

This PR is a suggestion to add this recommendation to the "designing-or-developing-for-multilingual-sites" quiz.