### PR TITLE
qns(quiz): Fix broken link in en-US.mdx

### DIFF
--- a/packages/quiz/questions/what-tools-and-techniques-do-you-use-for-debugging-javascript-code/en-US.mdx
+++ b/packages/quiz/questions/what-tools-and-techniques-do-you-use-for-debugging-javascript-code/en-US.mdx
@@ -3,7 +3,7 @@ title: What tools and techniques do you use for debugging JavaScript code?
 ---
 
 - JavaScript
-  - [Chrome Devtools](https://hackernoon.com/twelve-fancy-chrome-devtools-tips-dc1e39d10d9d)
+  - [Chrome Devtools](https://david-gilbertson.medium.com/twelve-fancy-chrome-devtools-tips-dc1e39d10d9d)
   - `debugger` statement
   - Traditional `console.log()` debugging
 - React and Redux


### PR DESCRIPTION
Replace the broken link in en-US.mdx with a blog post written by the same guy on the same topic. The previous link was leading to the hackernoon homepage.
