### PR TITLE
contents(company): update LinkedIn question tagging

### DIFF
--- a/contents/companies/linkedin-front-end-interview-questions.md
+++ b/contents/companies/linkedin-front-end-interview-questions.md
@@ -12,7 +12,7 @@ Front End Interview Handbook is now part of [GreatFrontEnd](https://www.greatfro
 ## JavaScript
 
 - Write a `getElementsByClassName` function.
-  - [Practice question](https://www.greatfrontend.com/questions/javascript/get-elements-by-class-name) (Free)
+  - [Practice question](https://www.greatfrontend.com/questions/javascript/get-elements-by-class-name) (Paid)
 
 ## User interface coding
 


### PR DESCRIPTION
The coding question was incorrectly labeled as Free. I was able to confirm the state by navigating to the question's URL through the hyperlink.

