### PR TITLE
contents: fix broken link in debugging section

### DIFF
--- a/contents/javascript-questions.md
+++ b/contents/javascript-questions.md
@@ -770,7 +770,7 @@ Practically, ES2015 has vastly improved JavaScript and made it much nicer to wri
 ###### References
 
 - https://hackernoon.com/twelve-fancy-chrome-devtools-tips-dc1e39d10d9d
-- https://raygun.com/blog/javascript-debugging/
+- https://raygun.com/learn/javascript-debugging-tips
 
 ### What language constructions do you use for iterating over object properties and array items?
 


### PR DESCRIPTION
I fixed a reference link that pointed to a moved Raygun blog post (which now results in a 404) to https://raygun.com/learn/javascript-debugging-tips

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
