### PR TITLE
contents: update and replace broken links in the English files of frontend interview playbook

### DIFF
--- a/packages/front-end-interview-guidebook/contents/algorithms/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/algorithms/en-US.mdx
@@ -118,4 +118,4 @@ During algorithmic coding interviews, interviewers are evaluating candidates on 
 
 ## Practice Questions
 
-Currently the best platform to practice algorithmic questions is undeniably LeetCode. However, GreatFrontEnd provides some [practice questions for Data Structures and Algorithms](/questions/js/coding/data-structures-algorithms) where you can practice implementing common data structures ([Stack](/questions/javascript/stack), [Queue](/questions/javascript/queue)) and algorithms ([Binary Search](/questions/javascript/binary-search), [Merge Sort](/questions/javascript/merge-sort)), etc in JavaScript.
+Currently the best platform to practice algorithmic questions is undeniably LeetCode. However, GreatFrontEnd provides some [practice questions for Data Structures and Algorithms](/questions/js/coding/data-structures-algorithms) where you can practice implementing common data structures ([Stack](/questions/algo/stack), [Queue](/questions/algo/queue)) and algorithms ([Binary Search](/questions/algo/binary-search), [Merge Sort](/questions/algo/merge-sort)), etc in JavaScript.

--- a/packages/front-end-interview-guidebook/contents/coding/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/coding/en-US.mdx
@@ -62,9 +62,9 @@ Here's a summary of the various coding environments and what you can do:
 
 Read on for tips for each coding interview type:
 
-- [Algorithmic Coding](/front-end-interview-guidebook/algorithms)
-- [JavaScript Coding](/front-end-interview-guidebook/javascript)
-- [User Interface Coding](/front-end-interview-guidebook/user-interface)
+- [Algorithmic Coding](/front-end-interview-playbook/algorithms)
+- [JavaScript Coding](/front-end-interview-playbook/javascript)
+- [User Interface Coding](/front-end-interview-playbook/user-interface)
 
 ## Practice Questions
 

--- a/packages/front-end-interview-guidebook/contents/javascript/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/javascript/en-US.mdx
@@ -69,7 +69,7 @@ JavaScript coding interviews share a lot of similarities with algorithmic coding
 
 ## How to Prepare for JavaScript Coding Interviews
 
-1. Be familiar with HTML, CSS, JavaScript, and DOM concepts by referring to the "Important Concepts" below. The [Quiz section](/front-end-interview-guidebook/quiz) can also be a good start since you might be asked on these concepts in the form of quiz questions during coding.
+1. Be familiar with HTML, CSS, JavaScript, and DOM concepts by referring to the "Important Concepts" below. The [Quiz section](/front-end-interview-playbook/quiz) can also be a good start since you might be asked on these concepts in the form of quiz questions during coding.
 1. Pick a [study plan](/get-started) and practice the [JavaScript coding questions](/questions/js/coding/utilities) recommended for the selected study plan. It's also alright to study for a certain topic as you are doing the questions.
 
 ## Important Concepts

--- a/packages/front-end-interview-guidebook/contents/overview/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/overview/en-US.mdx
@@ -14,7 +14,7 @@ However, many existing software engineering interview resources are geared towar
 
 Fear not! GreatFrontEnd aims to be the best resource for Front End Engineers to ace their front end interviews by being a one-stop platform to equip Front End Engineers with the necessary knowledge and practice. On GreatFrontEnd, readers can:
 
-1. Learn how to create an [**awesome resume tailored for Front End Engineering job listings**](/front-end-interview-guidebook/resume).
+1. Learn how to create an [**awesome resume tailored for Front End Engineering job listings**](/front-end-interview-playbook/resume).
 1. Learn **important front end concepts and techniques** that apply to all question types.
 1. Prepare for the most common **front end interview question types** (coding, system design, quiz, behavioral).
 1. [**Practice questions**](/questions) across the most common front end interview formats along with **high quality solutions** written by ex-FAANG Senior Engineers.
@@ -26,7 +26,7 @@ Your resume is the first opportunity to make an impression on potential employer
 
 If you are facing difficulties getting interviews for jobs you apply to despite having the necessary qualifications, it could be because of your resume. Even highly qualified candidates may not know how to effectively present their accomplishments in their resume and therefore may not get shortlisted. It is important to remember that being underqualified is not always the reason for not being selected; sometimes it is simply a matter of poor presentation and not including the important content. Once you have made it through the resume screening process, your past achievements are secondary and your technical skills become paramount, which can be learned and improved upon. Hence getting your foot in the door by submitting a great resume that represents you well is extremely important.
 
-While there are existing resources on how to make a good Software Engineering resume such as the [Tech Interview Handbook](https://www.techinterviewhandbook.org/resume/) and [FAANG Tech Leads' Resume Handbook](https://www.faangtechleads.com/resume/handbook), they are general and not specific to Front End Engineers. We have written some [tips on how to tailor your resume for Front End Engineering positions](/front-end-interview-guidebook/resume).
+While there are existing resources on how to make a good Software Engineering resume such as the [Tech Interview Handbook](https://www.techinterviewhandbook.org/resume/) and [FAANG Tech Leads' Resume Handbook](https://www.faangtechleads.com/resume/handbook), they are general and not specific to Front End Engineers. We have written some [tips on how to tailor your resume for Front End Engineering positions](/front-end-interview-playbook/resume).
 
 ## Prepare by Question Types
 
@@ -38,9 +38,9 @@ Each question format has its own challenges and quirks. We'll introduce you to t
 
 Coding questions will involve writing code (duh!). However, the code you will be required to write and the platforms you will write the code on can vary wildly. You could be asked about:
 
-1. **Algorithmic Coding**: Solve tricky algorithmic questions that evaluates your understanding of data structures, algorithms and time complexity. [Read about Algorithmic Coding Interviews](/front-end-interview-guidebook/algorithms).
-1. **JavaScript Coding**: Implement functions or data structures in JavaScript that are related to front end domain and commonly used during front end development. [Read about JavaScript Coding Interviews](/front-end-interview-guidebook/javascript).
-1. **User Interface Coding**: Build user interfaces (components, widgets, apps) using HTML, CSS, and JavaScript, sometimes even using JavaScript frameworks. [Read about User Interface Coding Interviews](/front-end-interview-guidebook/user-interface).
+1. **Algorithmic Coding**: Solve tricky algorithmic questions that evaluates your understanding of data structures, algorithms and time complexity. [Read about Algorithmic Coding Interviews](/front-end-interview-playbook/algorithms).
+1. **JavaScript Coding**: Implement functions or data structures in JavaScript that are related to front end domain and commonly used during front end development. [Read about JavaScript Coding Interviews](/front-end-interview-playbook/javascript).
+1. **User Interface Coding**: Build user interfaces (components, widgets, apps) using HTML, CSS, and JavaScript, sometimes even using JavaScript frameworks. [Read about User Interface Coding Interviews](/front-end-interview-playbook/user-interface).
 
 Companies are trending towards using domain-specific coding questions and less on testing about algorithms and data structures as the former is more relevant for evaluating the core skills needed for front end engineering work.
 
@@ -56,7 +56,7 @@ System design interviews are usually only given to senior level candidates and t
 
 Most of the time, Front End Engineers will be asked to design client applications and complex user interface components as those products are more relevant to front end engineering.
 
-[Read more about Front End System Design](/front-end-interview-guidebook/system-design)
+[Read more about Front End System Design](/front-end-interview-playbook/system-design)
 
 ### Quiz Questions
 
@@ -64,7 +64,7 @@ Quiz questions, also known as trivia questions, are short questions meant to tes
 
 There usually wouldn't be entire interview rounds just asking you quiz questions, but they could be sprung onto you in the middle of other interview rounds.
 
-[Read more about Quiz Questions](/front-end-interview-guidebook/quiz).
+[Read more about Quiz Questions](/front-end-interview-playbook/quiz).
 
 ## Behavioral Questions/Interviews
 
@@ -72,7 +72,7 @@ In behavioral interviews, interviewer asks questions about your past behaviors a
 
 The idea behind behavioral interviews is that past behaviors and experiences are good indicators of how someone will behave in the future, so the interviewer will ask questions that are designed to get you to describe specific situations you have faced and how you have dealt with them in order to get a better understanding about you beyond your technical capabilities.
 
-Behavioral interviews is a large topic on its own and we have [written an entire guidebook on it](/behavioral-interview-guidebook).
+Behavioral interviews is a large topic on its own and we have [written an entire playbook on it](/behavioral-interview-playbook).
 
 ## Typical Hiring Process
 
@@ -138,9 +138,9 @@ Here's a summary of the question types asked by the top US companies.
 
 Read on to find out how to prepare for the following front end interview formats/questions types:
 
-- [Coding Questions](/front-end-interview-guidebook/coding)
-  - [Algorithmic Questions](/front-end-interview-guidebook/algorithms)
-  - [JavaScript Questions](/front-end-interview-guidebook/javascript)
-  - [User Interface Questions](/front-end-interview-guidebook/user-interface)
-- [System Design Questions](/front-end-interview-guidebook/system-design)
-- [Quiz Questions](/front-end-interview-guidebook/quiz)
+- [Coding Questions](/front-end-interview-playbook/coding)
+  - [Algorithmic Questions](/front-end-interview-playbook/algorithms)
+  - [JavaScript Questions](/front-end-interview-playbook/javascript)
+  - [User Interface Questions](/front-end-interview-playbook/user-interface)
+- [System Design Questions](/front-end-interview-playbook/system-design)
+- [Quiz Questions](/front-end-interview-playbook/quiz)

--- a/packages/front-end-interview-guidebook/contents/quiz/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/quiz/en-US.mdx
@@ -54,6 +54,6 @@ We wouldn't recommend memorizing answers to quiz questions. It's best to truly u
 
 GreatFrontEnd contains a list of over 100 common quiz questions with detailed solutions written for each of them.
 
-- [JavaScript Quiz Questions](/questions/js/quiz)
-- [HTML Quiz Questions](/questions/html/quiz)
-- [CSS Quiz Questions](/questions/css/quiz)
+- [JavaScript Quiz Questions](/questions/javascript-interview-questions/quiz)
+- [HTML Quiz Questions](/questions/html-interview-questions/quiz)
+- [CSS Quiz Questions](/questions/css-interview-questions/quiz)

--- a/packages/front-end-interview-guidebook/contents/system-design/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/system-design/en-US.mdx
@@ -12,7 +12,7 @@ We have written a comprehensive [Front End System Design guide](/system-design) 
 
 ## Design Your System With Best Practices
 
-When going about the system design interview, regardless whether you are asked to design apps, games, or UI components, there are some things to pay special attention to. Incorporate the tips from our [User Interface Questions Cheatsheet](/front-end-interview-guidebook/user-interface-questions-cheatsheet) and elevate your front end interview game.
+When going about the system design interview, regardless whether you are asked to design apps, games, or UI components, there are some things to pay special attention to. Incorporate the tips from our [User Interface Questions Cheatsheet](/front-end-interview-playbook/user-interface-questions-cheatsheet) and elevate your front end interview game.
 
 ## Practice Questions
 

--- a/packages/front-end-interview-guidebook/contents/user-interface-components-api-design-principles/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/user-interface-components-api-design-principles/en-US.mdx
@@ -46,7 +46,7 @@ The slider can be customized by passing in a plain JavaScript object of options:
 
 ### Vanilla JavaScript Style
 
-There's no vanilla JavaScript style for initializing components since vanilla JavaScript is not a standard or framework. But if you have read enough of GreatFrontEnd's solutions for our vanilla JavaScript [UI coding questions](/questions/vanilla), you'll see that the API we recommend is similar to jQuery's, the constructor takes in a root element and options:
+There's no vanilla JavaScript style for initializing components since vanilla JavaScript is not a standard or framework. But if you have read enough of GreatFrontEnd's solutions for our vanilla JavaScript [UI coding questions](/questions/javascript-interview-questions/ui-coding), you'll see that the API we recommend is similar to jQuery's, the constructor takes in a root element and options:
 
 ```js
 function slider(rootEl, options) {

--- a/packages/front-end-interview-guidebook/contents/user-interface-questions-cheatsheet/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/user-interface-questions-cheatsheet/en-US.mdx
@@ -2,11 +2,11 @@
 title: Cheatsheet for UI Interview Questions
 description: A cheatsheet you can use to improve the user interfaces you have to build or design during front end interviews.
 seo_title: User Interface Questions Cheatsheet | Front End Interview Playbook
-seo_description: A cheatsheet you can use to improve the user interfaces you have to build or design during front end interviews - component organization, state design, UX and more 
+seo_description: A cheatsheet you can use to improve the user interfaces you have to build or design during front end interviews - component organization, state design, UX and more
 social_title: User Interface Questions Cheatsheet | Front End Interview Playbook
 ---
 
-Here are some tips you can use to improve the user interfaces you have to build/design during front end interviews. These can be applied to both [User Interface Coding Interviews](/front-end-interview-guidebook/user-interface) and [Front End System Design Interviews](/system-design/types-of-questions).
+Here are some tips you can use to improve the user interfaces you have to build/design during front end interviews. These can be applied to both [User Interface Coding Interviews](/front-end-interview-playbook/user-interface) and [Front End System Design Interviews](/system-design/types-of-questions).
 
 ## General
 
@@ -150,7 +150,7 @@ There's probably not enough time to handle all edge cases scenarios in your code
 
 ## Security
 
-- **Cross-site Scripting (XSS)**: Avoid assigning to [`Element.innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) or React's `dangerouslySetInnerHTML` when rendering contents into the DOM if it comes from users to prevent cross-site scripting, assign to [`Node.textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) or use the experimental[`Element.setHTML()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setHTML) method instead. Refer to [OWASP's XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- **Cross-site Scripting (XSS)**: Avoid assigning to [`Element.innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) or React's `dangerouslySetInnerHTML` when rendering contents into the DOM if it comes from users to prevent cross-site scripting, assign to [`Node.textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) or use the experimental[`Element.setHTML()`](https://webdocs.dev/en-us/docs/web/api/element/sethtml) method instead. Refer to [OWASP's XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
 - **Output encoding for "URL Contexts"**: If user-supplied input can be used in URL query parameters, use `encodeURIComponent` to prevent unintended values from becoming part of the URL (e.g. extra query parameters).
 - **Cross Site Request Forgery**: Refer to [OWASP's XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html).
 

--- a/packages/front-end-interview-guidebook/contents/user-interface/en-US.mdx
+++ b/packages/front-end-interview-guidebook/contents/user-interface/en-US.mdx
@@ -45,7 +45,7 @@ User interface coding interviews share a fair bit of similarity with non-front e
 1. Break down the problem into stages/milestones that build on top of each other. Communicate this breakdown to your interviewer. Unlike coding interviews, the focus of User Interface coding interviews is usually around the component states and APIs as opposed to complex data structures and algorithms.
 1. Code out your solution and explain your code to your interviewer while you are coding.
    - Where possible, test your code in the browser after every milestone/feature added, instead of only at the end.
-   - Refer to the [User Interface Questions Cheatsheet](/front-end-interview-guidebook/user-interface-questions-cheatsheet) for a list of things to take note of during User Interface coding interviews.
+   - Refer to the [User Interface Questions Cheatsheet](/front-end-interview-playbook/user-interface-questions-cheatsheet) for a list of things to take note of during User Interface coding interviews.
 1. After coding, read through your code once and try to spot basic errors like typos, using variables before initializing them, using APIs incorrectly, etc.
 1. Outline some basic test cases and some edge cases. Test your code with these cases and determine if your code passes them. If it fails, debug the issue(s) and fix them.
 1. Explain any tradeoffs you made, cases you explicitly didn't handle, and how you would improve the code if you had more time.
@@ -53,7 +53,7 @@ User interface coding interviews share a fair bit of similarity with non-front e
 
 ## How to Prepare for User Interface Coding Interviews
 
-1. Be familiar with the topics under the "Important Concepts" below. The [Quiz section](/front-end-interview-guidebook/quiz) can also be a good start since you might be asked on these concepts in the form of quiz questions during coding.
+1. Be familiar with the topics under the "Important Concepts" below. The [Quiz section](/front-end-interview-playbook/quiz) can also be a good start since you might be asked on these concepts in the form of quiz questions during coding.
 1. It's best to learn how to build UIs in both Vanilla JavaScript and a UI framework of choice. Most companies will allow using JavaScript UI frameworks but some companies (e.g. Google) mandate that you can only use Vanilla JavaScript.
    - **Vanilla JavaScript**: Learn the DOM manipulation APIs. At the very least you should know how to create new DOM elements, add classes/attributes to them, and add child elements. If you come from a [jQuery](https://jquery.com/) background, check out [You might not need jQuery](https://youmightnotneedjquery.com), a website showing you how to accomplish the common jQuery operations in Vanilla JavaScript. You will be pleasantly surprised to find out that with modern browser APIs there isn't really much need for jQuery anymore.
    - **JavaScript UI framework**: Be familiar with a UI framework of choice. Stick with the framework that you are most familiar with. There's no need and also probably not enough time to learn a new framework. If you are new to JavaScript UI frameworks, [React](https://reactjs.org/) will be our recommendation as it is the most popular library/framework to build UI right now and what most companies look for when hiring front end engineers.
@@ -61,8 +61,8 @@ User interface coding interviews share a fair bit of similarity with non-front e
    - **Write Vanilla CSS**: Learn to write CSS without reliance on preprocessors like Sass/Less. Not all coding environments will allow using processors and interview questions are likely small and do not really benefit from the features CSS preprocessors bring. The most useful feature of CSS processors is the use of variables, which is available natively via CSS custom properties (CSS variables).
    - **Adopt a CSS naming convention**: Consider adopting a CSS naming methodology like [Block Element Modifier](https://getbem.com) when writing your classes.
 1. Read our User Interface coding deep dive guides:
-   - [User Interface Questions Cheatsheet](/front-end-interview-guidebook/user-interface-questions-cheatsheet)
-   - [User Interface Components API Design Principles](/front-end-interview-guidebook/user-interface-components-api-design-principles)
+   - [User Interface Questions Cheatsheet](/front-end-interview-playbook/user-interface-questions-cheatsheet)
+   - [User Interface Components API Design Principles](/front-end-interview-playbook/user-interface-components-api-design-principles)
 1. Pick a [study plan](/get-started) and practice the [User Interface coding questions](/prepare/coding) recommended for the selected study plan.
    - Spend roughly equal amount of time practicing building both UI components and building apps/games. Both are equally important.
 
@@ -102,10 +102,10 @@ From experience, the best UI interview questions to practice, as determined by f
 - [Whack-a-mole](/questions/user-interface/whack-a-mole)
 - [Tic-tac-toe](/questions/user-interface/tic-tac-toe)
 - [Tabs](/questions/user-interface/tabs)
-- Image Carousel
+- [Image Carousel](/questions/user-interface/image-carousel)
 - Autocomplete
 - Dropdown Menu
-- Modal
+- [Modal](/questions/user-interface/modal-dialog)
 
 GreatFrontEnd has a [comprehensive list of User Interface coding questions](/prepare/coding) that you can practice in your framework of choice (currently supports Vanilla JavaScript and [React](https://reactjs.org/)). We also provide manual tests cases you can test your code against to verify the correctness and solutions written in the various JavaScript UI frameworks by ex-FAANG Senior Engineers. Automated test cases are not provided for UI questions because they tend to be coupled to implementation and hard for automated tests to test accurately. Moreover, during interviews you likely have to test your UI yourself.
 


### PR DESCRIPTION
Here are my following changes in the English files of frontend interview playbook:
- Update broken links to correct format
- Replace broken external links with correct ones

