### PR TITLE
fix: Delete the useless en origin texts in zh-CN translation.

### DIFF
--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/javascript-questions.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/javascript-questions.md
@@ -648,7 +648,7 @@ TODO.
 
 ### 用转译成 JavaScript 的语言写 JavaScript 有什么优缺点？
 
-Some examples of languages that compile to JavaScript include CoffeeScript, Elm, ClojureScript, PureScript and TypeScript. 这些是转译成 JavaScript 的语言，包括 CoffeeScript、Elm、ClojureScript、PureScript 和 TypeScript。
+这些是转译成 JavaScript 的语言，包括 CoffeeScript、Elm、ClojureScript、PureScript 和 TypeScript。
 
 **优点：**
 


### PR DESCRIPTION
<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->

There are some origin en texts which untranslated in zh-CN translations. Remove it for fix.