### PR TITLE
[feih] contents/resume: fix broken link in "Resume Preparation" page

### DIFF
--- a/contents/resume.md
+++ b/contents/resume.md
@@ -30,7 +30,7 @@ They also offer resume examples/references from candidates who have received mul
 
 ### 2. Test readability with industry-standard ATS
 
-Test the readability and formatting of your resume using [OpenResume, a free resume parser]([https://nodeflair.com/resume-checker](https://www.open-resume.com/)). Most big companies use similar resume scanners.
+Test the readability and formatting of your resume using [OpenResume](https://www.open-resume.com/) or [NodeFlair Resume Checker](https://nodeflair.com/resume-checker). Most big companies use similar resume scanners.
 
 ### 3. The plain text file test
 

--- a/contents/resume.md
+++ b/contents/resume.md
@@ -30,7 +30,7 @@ They also offer resume examples/references from candidates who have received mul
 
 ### 2. Test readability with industry-standard ATS
 
-Test the readability and formatting of your resume using [OpenResume, a free resume parser](https://www.open-resume.com/) or [NodeFlair, a free resume ATS checker](https://nodeflair.com/resume-checker). Most big companies use similar resume scanners.
+Test the readability and formatting of your resume using [OpenResume, a free resume parser](https://www.open-resume.com/resume-parser) or [NodeFlair's free resume ATS checker](https://nodeflair.com/resume-checker). Most big companies use similar resume scanners.
 
 ### 3. The plain text file test
 

--- a/contents/resume.md
+++ b/contents/resume.md
@@ -30,7 +30,7 @@ They also offer resume examples/references from candidates who have received mul
 
 ### 2. Test readability with industry-standard ATS
 
-Test the readability and formatting of your resume using [OpenResume](https://www.open-resume.com/) or [NodeFlair Resume Checker](https://nodeflair.com/resume-checker). Most big companies use similar resume scanners.
+Test the readability and formatting of your resume using [OpenResume, a free resume parser](https://www.open-resume.com/) or [NodeFlair, a free resume ATS checker](https://nodeflair.com/resume-checker). Most big companies use similar resume scanners.
 
 ### 3. The plain text file test
 


### PR DESCRIPTION
Originally the link was written with incorrect markdown syntax, nesting two links inside a top-level `[]()`, clicking on which would lead to a 404. I assume the previous editor wanted to showcase both sources of checking your resume (one gives ATS score, another lets you know how well your resume can be parsed) so updated the markdown to show both links

<!--
We typically do not accept submissions for new questions. This is because the [original questions repository](https://github.com/h5bp/Front-end-Developer-Interview-Questions) has been curated by a team of industry professionals and we use it as ground truth and keep our answers in sync with the questions/answers as much as possible. If you are keen to add a question/answer, firstly try to submit an issue/pull request to that repository, once your question is merged, you can then make a pull request with your answers to this repository.

You are welcome to make improvements to existing answers and/or answer unanswered questions. Try to add a list of references you used when arriving at the answers or any supplementary material that might be useful. This would be helpful for readers who would like to go further in-depth into the answer.
-->
