### PR TITLE
[feih] fix: resolve gfe spotlight ad issue on safari

### DIFF
--- a/website/src/components/SidebarAd/styles.module.css
+++ b/website/src/components/SidebarAd/styles.module.css
@@ -64,6 +64,14 @@
   display: flex;
   border-radius: var(--border-radius);
   background-color: transparent;
+  position: relative;
+}
+
+.container::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
   background-image:
     conic-gradient(
       from var(--border-angle-1) at 10% 15%,
@@ -90,6 +98,7 @@
     rotateBackground 3s linear infinite,
     rotateBackground2 8s linear infinite,
     rotateBackground3 13s linear infinite;
+  z-index: -1;
 }
 
 .container:hover {


### PR DESCRIPTION
Problem
Safari showed sharp corners instead of rounded borders on the gradient animations, while Chrome/Firefox worked fine.

Fix
Moved the gradient background to a ::before pseudo-element. Safari handles gradients better when they're on a separate layer from the content.

**Special Notes**
While there isn't any regression in Chrome/Firefox, Firefox's spotlight ad seems to be static while in Chrome/Safari there is animation. 