### PR TITLE
[feih] seo: fix canonical points to redirect

### DIFF
--- a/website/blog/2021-08-30-a-glimpse-into-front-end-interviews.md
+++ b/website/blog/2021-08-30-a-glimpse-into-front-end-interviews.md
@@ -10,7 +10,7 @@ hide_table_of_contents: true
 ---
 
 <head>
-  <link rel="canonical" href="https://lik.ai/blog/a-glimpse-into-front-end-interviews" />
+  <link rel="canonical" href="https://lik.ai/blog/a-glimpse-into-front-end-interviews/" />
 </head>
 
 A glimpse into the front end interview process and questions that frequently come up.


### PR DESCRIPTION
Fixed Canonical points to redirect issue from Ahrefs

`https://lik.ai/blog/a-glimpse-into-front-end-interviews` now redirects to `https://lik.ai/blog/a-glimpse-into-front-end-interviews/`

Updated the canonical link accordingly