### PR TITLE
[feih} seo: fix non canonical page in sitemap issue

### DIFF
--- a/website/blog/2021-08-30-a-glimpse-into-front-end-interviews.md
+++ b/website/blog/2021-08-30-a-glimpse-into-front-end-interviews.md
@@ -10,7 +10,7 @@ hide_table_of_contents: true
 ---
 
 <head>
-  <link rel="canonical" href="https://lik.ai/blog/a-glimpse-into-front-end-interviews/" />
+  <link rel="canonical" href="https://lik.ai/blog/a-glimpse-into-front-end-interviews" />
 </head>
 
 A glimpse into the front end interview process and questions that frequently come up.

--- a/website/blog/2021-08-30-a-glimpse-into-front-end-interviews.md
+++ b/website/blog/2021-08-30-a-glimpse-into-front-end-interviews.md
@@ -10,7 +10,7 @@ hide_table_of_contents: true
 ---
 
 <head>
-  <link rel="canonical" href="https://lik.ai/blog/a-glimpse-into-front-end-interviews" />
+  <link rel="canonical" href="https://lik.ai/blog/a-glimpse-into-front-end-interviews/" />
 </head>
 
 A glimpse into the front end interview process and questions that frequently come up.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -211,7 +211,7 @@ module.exports = {
           trackingID: 'G-D9B6CHX36V',
         },
         sitemap: {
-          ignorePatterns: ['/blog/**'],
+          ignorePatterns: ['/blog/tags/javascript', 'blog/tags/career', 'blog/tags/map', 'blog/tags/object', 'blog/tags/interview', 'blog/tags/front-end', 'blog', 'blog/blog/javascript-object-vs-map', 'blog/a-glimpse-into-front-end-interviews', '/blog/front-end-career-questions', 'blog/are-front-end-development-skills-enough-for-a-career'],
         },
       },
     ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -210,6 +210,9 @@ module.exports = {
         gtag: {
           trackingID: 'G-D9B6CHX36V',
         },
+        sitemap: {
+          ignorePatterns: ['/blog/**'],
+        },
       },
     ],
   ],


### PR DESCRIPTION
As 4/5 of the blog posts on FEIH have canoical links & are included in the sitemap, various slugs have flagged the issue of Non-canonical page in sitemap

1) /blog
2) /blog/[blog-post]
3) /blog/tags/[tag]

**Fix**
Remove affected `/blog` slugs in sitemap

**Special Notes**
There is one post for "Front End vs. Back End System Design Interviews" that does not have a canonical link, which will stay in the sitemap. Hence, a blanket `/blog/**` wasn't used