### PR TITLE
[feih] seo: fix meta description too short issue

### DIFF
--- a/contents/algorithms.md
+++ b/contents/algorithms.md
@@ -2,6 +2,7 @@
 title: Algorithms Interview Questions (Machine Coding) in Front End Interviews
 slug: coding/algorithms
 sidebar_label: Algorithms coding
+description: Master algorithms for front-end developers. Practice data structures, tree traversals & JavaScript coding problems with free resources and expert guidance.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/algorithms.md
+++ b/contents/algorithms.md
@@ -2,7 +2,7 @@
 title: Algorithms Interview Questions (Machine Coding) in Front End Interviews
 slug: coding/algorithms
 sidebar_label: Algorithms coding
-description: Master algorithms for front-end developers. Practice data structures, tree traversals & JavaScript coding problems with free resources and expert guidance.
+description: Master algorithms for front end developers. Practice data structures, tree traversals & JavaScript coding problems with free resources and expert guidance.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/build-front-end-user-interfaces.md
+++ b/contents/build-front-end-user-interfaces.md
@@ -2,6 +2,7 @@
 title: User Interface Interview Questions (Machine Coding) in Front End Interviews
 slug: coding/build-front-end-user-interfaces
 sidebar_label: User interface coding
+description: Master coded UI interview questions with 200+ practice problems. Learn components, widgets, apps & games with React, Vue, Angular solutions on GreatFrontEnd
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/adobe-front-end-interview-questions.md
+++ b/contents/companies/adobe-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Adobe Front End Interview Questions
 sidebar_label: Adobe interview questions
+description: Adobe Front End Interview Questions guide with real interview experiences, coding challenges, and insider tips for 2025.
 ---
 
 ## Insider tips from the GreatFrontEnd community

--- a/contents/companies/airbnb-front-end-interview-questions.md
+++ b/contents/companies/airbnb-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Airbnb Front End Interview Questions
 sidebar_label: Airbnb interview questions
-description: Airbnb frontend interview questions covering JavaScript coding, UI development, system design, and LeetCode problems with real candidate experiences.
+description: Airbnb front end interview questions covering JavaScript coding, UI development, system design, and LeetCode problems with real candidate experiences.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/airbnb-front-end-interview-questions.md
+++ b/contents/companies/airbnb-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Airbnb Front End Interview Questions
 sidebar_label: Airbnb interview questions
+description: Airbnb frontend interview questions covering JavaScript coding, UI development, system design, and LeetCode problems with real candidate experiences.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/airbnb-front-end-interview-questions.md
+++ b/contents/companies/airbnb-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Airbnb Front End Interview Questions
 sidebar_label: Airbnb interview questions
-description: Airbnb front end interview questions covering JavaScript coding, UI development, system design, and LeetCode problems with real candidate experiences.
+description: Airbnb frontend interview questions covering JavaScript coding, UI development, system design, and LeetCode problems with real candidate experiences.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/amazon-front-end-interview-questions.md
+++ b/contents/companies/amazon-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Front End Interview Questions
 sidebar_label: Amazon interview questions
+description: Complete Amazon front end developer interview guide with coding questions, system design, Leadership Principles, and insider tips from candidates.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/apple-front-end-interview-questions.md
+++ b/contents/companies/apple-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Apple Front End Interview Questions
 sidebar_label: Apple interview questions
-description: Apple frontend interview questions & answers including JavaScript coding, UI challenges, and insider tips to help you land your dream Apple job.
+description: Apple front end interview questions & answers including JavaScript coding, UI challenges, and insider tips to help you land your dream Apple job.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/apple-front-end-interview-questions.md
+++ b/contents/companies/apple-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Apple Front End Interview Questions
 sidebar_label: Apple interview questions
-description: Apple front end interview questions & answers including JavaScript coding, UI challenges, and insider tips to help you land your dream Apple job.
+description: Apple frontend interview questions & answers including JavaScript coding, UI challenges, and insider tips to help you land your dream Apple job.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/apple-front-end-interview-questions.md
+++ b/contents/companies/apple-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Apple Front End Interview Questions
 sidebar_label: Apple interview questions
+description: Apple frontend interview questions & answers including JavaScript coding, UI challenges, and insider tips to help you land your dream Apple job.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/bytedance-tiktok-front-end-interview-questions.md
+++ b/contents/companies/bytedance-tiktok-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: ByteDance/TikTok Front End Interview Questions
 sidebar_label: ByteDance/TikTok interview questions
-description: Master TikTok front end engineer interviews with real coding questions, UI components, algorithms & insider tips from successful candidates.
+description: Master TikTok frontend engineer interviews with real coding questions, UI components, algorithms & insider tips from successful candidates.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/bytedance-tiktok-front-end-interview-questions.md
+++ b/contents/companies/bytedance-tiktok-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: ByteDance/TikTok Front End Interview Questions
 sidebar_label: ByteDance/TikTok interview questions
+description: Master TikTok frontend engineer interviews with real coding questions, UI components, algorithms & insider tips from successful candidates.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/bytedance-tiktok-front-end-interview-questions.md
+++ b/contents/companies/bytedance-tiktok-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: ByteDance/TikTok Front End Interview Questions
 sidebar_label: ByteDance/TikTok interview questions
-description: Master TikTok frontend engineer interviews with real coding questions, UI components, algorithms & insider tips from successful candidates.
+description: Master TikTok front end engineer interviews with real coding questions, UI components, algorithms & insider tips from successful candidates.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/dropbox-front-end-interview-questions.md
+++ b/contents/companies/dropbox-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Dropbox Front End Interview Questions
 sidebar_label: Dropbox interview questions
+description: "Complete Dropbox front end interview guide: coding questions, UI challenges & system design. Real JavaScript, HTML/CSS examples plus insider tips."
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/google-front-end-interview-questions.md
+++ b/contents/companies/google-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Google Front End Interview Questions
 sidebar_label: Google interview questions
+description: "Complete Google front-end interview guide: JavaScript coding, UI components, system design & DSA. Practice questions for L4-L6 roles."
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/google-front-end-interview-questions.md
+++ b/contents/companies/google-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Google Front End Interview Questions
 sidebar_label: Google interview questions
-description: "Complete Google front-end interview guide: JavaScript coding, UI components, system design & DSA. Practice questions for L4-L6 roles."
+description: "Complete Google front end interview guide: JavaScript coding, UI components, system design & DSA. Practice questions for L4-L6 roles."
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/linkedin-front-end-interview-questions.md
+++ b/contents/companies/linkedin-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: LinkedIn Front End Interview Questions
 sidebar_label: LinkedIn interview questions
+description: "LinkedIn front end interview questions: JavaScript coding, UI components, algorithms & quiz questions. Real candidate experiences & insider tips."
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/lyft-front-end-interview-questions.md
+++ b/contents/companies/lyft-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Lyft Front End Interview Questions
 sidebar_label: Lyft interview questions
+description: Lyft front end interview questions with JavaScript coding challenges, UI problems, and insider tips from successful candidates. 
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/meta-front-end-interview-questions.md
+++ b/contents/companies/meta-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Meta Front End Interview Questions
 sidebar_label: Meta interview questions
+description: Master Meta front end interviews with real insider tips, coding challenges, and proven strategies from successful candidates. Free expert guide.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/microsoft-front-end-interview-questions.md
+++ b/contents/companies/microsoft-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Front End Interview Questions
 sidebar_label: Microsoft interview questions
+description: Microsoft coding round questions & system design interview prep. JavaScript, React, DOM concepts + real candidate experiences and insider tips.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/oracle-front-end-interview-questions.md
+++ b/contents/companies/oracle-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Oracle Front End Interview Questions
 sidebar_label: Oracle interview questions
+description: Oracle front end interview questions with real SDE-3 experience. DSA, JavaScript, React, system design & behavioral rounds. Insider tips included.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/palantir-front-end-interview-questions.md
+++ b/contents/companies/palantir-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Palantir Front End Interview Questions
 sidebar_label: Palantir interview questions
+description: Palantir frontend interview guide with real candidate experiences. Master leetcode problems, algorithms & system design for tech interviews.
 ---
 
 ## Insider tips from the GreatFrontEnd community

--- a/contents/companies/palantir-front-end-interview-questions.md
+++ b/contents/companies/palantir-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Palantir Front End Interview Questions
 sidebar_label: Palantir interview questions
-description: Palantir front end interview guide with real candidate experiences. Master leetcode problems, algorithms & system design for tech interviews.
+description: Palantir frontend interview guide with real candidate experiences. Master leetcode problems, algorithms & system design for tech interviews.
 ---
 
 ## Insider tips from the GreatFrontEnd community

--- a/contents/companies/palantir-front-end-interview-questions.md
+++ b/contents/companies/palantir-front-end-interview-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Palantir Front End Interview Questions
 sidebar_label: Palantir interview questions
-description: Palantir frontend interview guide with real candidate experiences. Master leetcode problems, algorithms & system design for tech interviews.
+description: Palantir front end interview guide with real candidate experiences. Master leetcode problems, algorithms & system design for tech interviews.
 ---
 
 ## Insider tips from the GreatFrontEnd community

--- a/contents/companies/pinterest-front-end-interview-questions.md
+++ b/contents/companies/pinterest-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Pinterest Front End Interview Questions
 sidebar_label: Pinterest interview questions
+description: Get insider Pinterest front end interview tips from real candidates. Covers React coding, system design, algorithms & behavioral rounds.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/reddit-front-end-interview-questions.md
+++ b/contents/companies/reddit-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Reddit Front End Interview Questions
 sidebar_label: Reddit interview questions
+description: Reddit front end interview guide with real candidate experiences. JavaScript fundamentals, HTML forms, array problems, and system design tips
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/salesforce-front-end-interview-questions.md
+++ b/contents/companies/salesforce-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Salesforce Front End Interview Questions
 sidebar_label: Salesforce interview questions
+description: "Salesforce front end developer interview questions: coding challenges, JavaScript quiz on event loop, closures, CSS positioning. Real experiences & tips."
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/shopify-front-end-interview-questions.md
+++ b/contents/companies/shopify-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Shopify Front End Interview Questions
 sidebar_label: Shopify interview questions
+description: Ace your Shopify front end interview with real questions, insider tips from successful candidates, and coding challenges. Latest prep strategies.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/twitter-front-end-interview-questions.md
+++ b/contents/companies/twitter-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: X/Twitter Front End Interview Questions
 sidebar_label: Twitter interview questions
+description: "Get X (Twitter) front end interview questions & coding challenges. Practice typeahead, tic-tac-toe problems & JavaScript concepts plus insider tips."
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/companies/uber-front-end-interview-questions.md
+++ b/contents/companies/uber-front-end-interview-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Uber Front End Interview Questions
 sidebar_label: Uber interview questions
+description: "Complete Uber front end interview guide: JavaScript coding, UI challenges, rate limiters, progress bars & insider tips. Latest 2025 experiences included."
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/css-questions.md
+++ b/contents/css-questions.md
@@ -1,7 +1,7 @@
 ---
 title: CSS Interview Questions (Quiz) for Front End Interviews
 sidebar_label: CSS quiz
-description: Master CSS interview questions with comprehensive answers on specificity, box model, flexbox, grid, positioning & more. Perfect prep for front end roles.
+description: Master CSS interview questions with comprehensive answers on specificity, box model, flexbox, grid, positioning & more. Perfect prep for frontend roles.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/css-questions.md
+++ b/contents/css-questions.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Interview Questions (Quiz) for Front End Interviews
 sidebar_label: CSS quiz
+description: Master CSS interview questions with comprehensive answers on specificity, box model, flexbox, grid, positioning & more. Perfect prep for frontend roles.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/css-questions.md
+++ b/contents/css-questions.md
@@ -1,7 +1,7 @@
 ---
 title: CSS Interview Questions (Quiz) for Front End Interviews
 sidebar_label: CSS quiz
-description: Master CSS interview questions with comprehensive answers on specificity, box model, flexbox, grid, positioning & more. Perfect prep for frontend roles.
+description: Master CSS interview questions with comprehensive answers on specificity, box model, flexbox, grid, positioning & more. Perfect prep for front end roles.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design-applications.md
+++ b/contents/front-end-system-design-applications.md
@@ -2,7 +2,7 @@
 title: Front End System Design Interview - Applications
 slug: front-end-system-design/applications
 sidebar_label: Applications
-description: Master frontend system design interviews with the RADIO framework. Real examples from Facebook, Instagram, Netflix with senior engineer insights.
+description: Master front end system design interviews with the RADIO framework. Real examples from Facebook, Instagram, Netflix with senior engineer insights.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design-applications.md
+++ b/contents/front-end-system-design-applications.md
@@ -2,6 +2,7 @@
 title: Front End System Design Interview - Applications
 slug: front-end-system-design/applications
 sidebar_label: Applications
+description: Master frontend system design interviews with the RADIO framework. Real examples from Facebook, Instagram, Netflix with senior engineer insights.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design-applications.md
+++ b/contents/front-end-system-design-applications.md
@@ -2,7 +2,7 @@
 title: Front End System Design Interview - Applications
 slug: front-end-system-design/applications
 sidebar_label: Applications
-description: Master front end system design interviews with the RADIO framework. Real examples from Facebook, Instagram, Netflix with senior engineer insights.
+description: Master frontend system design interviews with the RADIO framework. Real examples from Facebook, Instagram, Netflix with senior engineer insights.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design-ui-components.md
+++ b/contents/front-end-system-design-ui-components.md
@@ -2,6 +2,7 @@
 title: Front End System Design Interview - User Interface Components
 slug: front-end-system-design/ui-components
 sidebar_label: User interface components
+description: Complete guide to frontend system design interviews for UI components. Learn the RADIO framework with real examples and optimization techniques.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design-ui-components.md
+++ b/contents/front-end-system-design-ui-components.md
@@ -2,7 +2,7 @@
 title: Front End System Design Interview - User Interface Components
 slug: front-end-system-design/ui-components
 sidebar_label: User interface components
-description: Complete guide to frontend system design interviews for UI components. Learn the RADIO framework with real examples and optimization techniques.
+description: Complete guide to front end system design interviews for UI components. Learn the RADIO framework with real examples and optimization techniques.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design-ui-components.md
+++ b/contents/front-end-system-design-ui-components.md
@@ -2,7 +2,7 @@
 title: Front End System Design Interview - User Interface Components
 slug: front-end-system-design/ui-components
 sidebar_label: User interface components
-description: Complete guide to front end system design interviews for UI components. Learn the RADIO framework with real examples and optimization techniques.
+description: Complete guide to frontend system design interviews for UI components. Learn the RADIO framework with real examples and optimization techniques.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design.md
+++ b/contents/front-end-system-design.md
@@ -1,6 +1,7 @@
 ---
 title: Front End System Design Interview Overview
 sidebar_label: Overview
+description: Master front-end system design interviews with our comprehensive guide. UI components, applications, RADIO framework + free examples included.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/front-end-system-design.md
+++ b/contents/front-end-system-design.md
@@ -1,7 +1,7 @@
 ---
 title: Front End System Design Interview Overview
 sidebar_label: Overview
-description: Master front-end system design interviews with our comprehensive guide. UI components, applications, RADIO framework + free examples included.
+description: Master front end system design interviews with our comprehensive guide. UI components, applications, RADIO framework + free examples included.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/html-questions.md
+++ b/contents/html-questions.md
@@ -1,7 +1,7 @@
 ---
 title: HTML Interview Questions (Quiz) for Front End Interviews
 sidebar_label: HTML quiz
-description: Complete HTML interview questions guide with detailed answers on DOCTYPE, storage types, templating, and multilingual sites for frontend developers
+description: Complete HTML interview questions guide with detailed answers on DOCTYPE, storage types, templating, and multilingual sites for front end developers
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/html-questions.md
+++ b/contents/html-questions.md
@@ -1,7 +1,7 @@
 ---
 title: HTML Interview Questions (Quiz) for Front End Interviews
 sidebar_label: HTML quiz
-description: Complete HTML interview questions guide with detailed answers on DOCTYPE, storage types, templating, and multilingual sites for front end developers
+description: Complete HTML interview questions guide with detailed answers on DOCTYPE, storage types, templating, and multilingual sites for frontend developers
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/html-questions.md
+++ b/contents/html-questions.md
@@ -1,6 +1,7 @@
 ---
 title: HTML Interview Questions (Quiz) for Front End Interviews
 sidebar_label: HTML quiz
+description: Complete HTML interview questions guide with detailed answers on DOCTYPE, storage types, templating, and multilingual sites for frontend developers
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/introduction.md
+++ b/contents/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: "Complete frontend developer interview guide: JavaScript coding questions, UI components, system design, quiz prep & expert tips from ex FAANG engineers."
+description: "Complete front end developer interview guide: JavaScript coding questions, UI components, system design, quiz prep & expert tips from ex FAANG engineers."
 
 ---
 

--- a/contents/introduction.md
+++ b/contents/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: "Complete front end developer interview guide: JavaScript coding questions, UI components, system design, quiz prep & expert tips from ex FAANG engineers."
+description: "Complete frontend developer interview guide: JavaScript coding questions, UI components, system design, quiz prep & expert tips from ex FAANG engineers."
 
 ---
 

--- a/contents/introduction.md
+++ b/contents/introduction.md
@@ -1,5 +1,7 @@
 ---
 title: Introduction
+description: "Complete frontend developer interview guide: JavaScript coding questions, UI components, system design, quiz prep & expert tips from ex FAANG engineers."
+
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/javascript-questions.md
+++ b/contents/javascript-questions.md
@@ -1,6 +1,7 @@
 ---
 title: JavaScript Interview Questions (Quiz) for Front End Interviews
 sidebar_label: JavaScript quiz
+description: Master JavaScript interview prep with 50+ essential coding questions, quiz topics, and detailed answers for front end developers. Practice now
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/javascript-utility-function.md
+++ b/contents/javascript-utility-function.md
@@ -2,7 +2,7 @@
 title: JavaScript Interview Questions (Machine Coding) for Front End Interviews
 slug: coding/javascript-utility-function
 sidebar_label: JavaScript coding
-description: Master JavaScript machine coding for front-end interviews. Practice debounce, throttle, Promise.all & essential utilities with real examples.
+description: Master JavaScript machine coding for front end interviews. Practice debounce, throttle, Promise.all & essential utilities with real examples.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/javascript-utility-function.md
+++ b/contents/javascript-utility-function.md
@@ -2,6 +2,7 @@
 title: JavaScript Interview Questions (Machine Coding) for Front End Interviews
 slug: coding/javascript-utility-function
 sidebar_label: JavaScript coding
+description: Master JavaScript machine coding for front-end interviews. Practice debounce, throttle, Promise.all & essential utilities with real examples.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/resume.md
+++ b/contents/resume.md
@@ -1,6 +1,6 @@
 ---
 title: Resume preparation
-description: "Front end engineer resume guide: Expert templates, ATS tips, and FAANG hiring manager strategies to land your dream tech job"
+description: "Frontend engineer resume guide: Expert templates, ATS tips, and FAANG hiring manager strategies to land your dream tech job"
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/resume.md
+++ b/contents/resume.md
@@ -1,6 +1,6 @@
 ---
 title: Resume preparation
-description: "Frontend engineer resume guide: Expert templates, ATS tips, and FAANG hiring manager strategies to land your dream tech job"
+description: "Front end engineer resume guide: Expert templates, ATS tips, and FAANG hiring manager strategies to land your dream tech job"
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/resume.md
+++ b/contents/resume.md
@@ -1,5 +1,6 @@
 ---
 title: Resume preparation
+description: "Frontend engineer resume guide: Expert templates, ATS tips, and FAANG hiring manager strategies to land your dream tech job"
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/trivia.md
+++ b/contents/trivia.md
@@ -1,6 +1,7 @@
 ---
 title: Quiz/trivia questions in front end interviews
 sidebar_label: Overview
+description: Master coding trivia for front-end interviews. Practice JavaScript, CSS & React questions on closures, promises, box model + more with expert solutions.
 ---
 
 :::info Latest version on GreatFrontEnd

--- a/contents/trivia.md
+++ b/contents/trivia.md
@@ -1,7 +1,7 @@
 ---
 title: Quiz/trivia questions in front end interviews
 sidebar_label: Overview
-description: Master coding trivia for front-end interviews. Practice JavaScript, CSS & React questions on closures, promises, box model + more with expert solutions.
+description: Master coding trivia for front end interviews. Practice JavaScript, CSS & React questions on closures, promises, box model + more with expert solutions.
 ---
 
 :::info Latest version on GreatFrontEnd


### PR DESCRIPTION
Fixed Meta description too short issue flagged on Ahrefs by including custom meta descriptions that are within 110-160 characters for affected pages. 